### PR TITLE
Setting up the build environments for Mac and (eventually Linux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Outputs
+dist/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+CC := g++
+CFLAGS := -std=c++11 -Wall -Wextra
+
+# Architecture specific settings
+ifeq ($(shell uname), Linux)
+    OS := Linux
+else ifeq ($(shell uname), Darwin)
+    OS := Mac
+else ifeq ($(shell uname), Windows_NT)
+    OS := Windows
+else
+    $(error Unsupported operating system: $(shell uname))
+endif
+
+SRCDIR := src
+ROOTBUILDDIR := build
+ROOTDISTDIR := dist
+BUILDDIR := $(ROOTBUILDDIR)/$(OS)
+DISTDIR := $(ROOTDISTDIR)/$(OS)
+TARGET := $(DISTDIR)/core-engine
+
+SRCEXT := cpp
+SOURCES := $(shell find $(SRCDIR) -type f -name *.$(SRCEXT))
+OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
+
+$(TARGET): $(OBJECTS)
+	@echo "Linking..."
+	@mkdir -p $(DISTDIR)
+	$(CC) $^ -o $(TARGET)
+	@echo "Build complete!"
+
+$(BUILDDIR)/%.o: $(SRCDIR)/%.$(SRCEXT)
+	@mkdir -p $(dir $@)
+	@echo "Compiling $<..."
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	@echo "Cleaning..."
+	$(RM) -r $(ROOTBUILDDIR) $(ROOTDISTDIR)
+	@echo "Clean complete!"
+
+.PHONY: clean

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
-# core
-
+# Core
 core game engine for upcoming voxel based game
+
+# Building
+We currently support building for Linux and MacOS with plans to add support for windows (as soon as we figure out how)
+
+For now, you can target the current platform with:
+```
+$ ./build.sh
+```
+
+If you would also like to output for the current executable use:
+```
+$ ./build-and-run.sh
+```
+
+For Linux:
+```
+$ ./build.sh (-tp|--target-platforms) Linux
+```
+and to run:
+```
+$ ./build-and-run.sh (-tp|--target-platforms) Linux
+```
+
 
 # References
 https://hub.docker.com/_/gcc/

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+bash build.sh "$@"
+
+# Determine the operating system
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     os=Linux;;
+    Darwin*)    os=Mac;;
+    CYGWIN*)    os=Windows;;
+    MINGW*)     os=Windows;;
+    *)          os="UNKNOWN:${unameOut}"
+esac
+
+dist/$os/core-engine

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,35 @@
-docker build -t core-engine ./buildenv
-docker run --rm -v "$PWD":/src -w /usr/src/ gcc:4.9 make
+#!/bin/bash
+
+function build_linux()
+{
+    docker build -t core-engine ./buildenv
+    docker run --rm -v "$PWD":/usr/core core-engine make
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -tp|--target-platforms)
+            TARGETS="$2"
+            shift
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Check if target architectures are specified and call the appropriate build function
+if [[ -n "${TARGETS[*]}" ]]; then
+    if [[ "${TARGETS[*]}" == *"Linux"* ]]; then
+        build_linux "${TARGETS[*]}"
+    else
+        echo "Unsupported target architecture: ${TARGETS[*]}"
+        exit 1
+    fi
+else
+    make
+fi

--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -1,1 +1,3 @@
 FROM gcc:4.9
+
+WORKDIR /usr/core


### PR DESCRIPTION
This PR is doing the initial groundwork for a cross platform build system for our engine. It will have to be built on once we start adding new dependencies and what-not and full support for linux and eventually windows.

Currently, if you want run on linux you have to open a linux container and run the build-and-run.sh script but I would like to add support for running the linux version from anywhere.